### PR TITLE
add arguments camera_info_file_{left,right} to set calib files when incl...

### DIFF
--- a/launch/stereo.launch
+++ b/launch/stereo.launch
@@ -7,9 +7,13 @@
   <arg unless="$(arg respawn)" name="bond" value="--no-bond" />
 
   <!-- arguments for camera param uri -->
+  <arg name="camera_info_file_right"
+       default="$(find ps4eye)/camera_info/right.yaml" />
+  <arg name="camera_info_file_left"
+       default="$(find ps4eye)/camera_info/left.yaml" />
   <arg name="camera_info_url_default" default="file://$(find ps4eye)/camera_info/default.yaml" />
-  <arg name="camera_info_url_right" default="file://$(find ps4eye)/camera_info/right.yaml" />
-  <arg name="camera_info_url_left" default="file://$(find ps4eye)/camera_info/left.yaml" />
+  <arg name="camera_info_url_right" default="file://$(arg camera_info_file_right)" />
+  <arg name="camera_info_url_left" default="file://$(arg camera_info_file_left)" />
 
   <!-- arguments for tf coords -->
   <arg name="parent_frame" default="/map" />
@@ -45,7 +49,7 @@
     <remap from="camera_out/image_raw" to="/stereo/right/image_raw" />
     <!-- Dont use original camera info -->
     <remap from="/stereo/right/camera_info" to="/null/right/camera_info" />
-  </node>  
+  </node>
   <node pkg="nodelet" type="nodelet" name="split_left" args="load image_proc/crop_decimate standalone">
     <param name="camera_info_url" value="$(arg camera_info_url_left)" />
     <param name="queue_size" type="int" value="10" />
@@ -58,12 +62,12 @@
     <remap from="camera_out/image_raw" to="/stereo/left/image_raw" />
     <!-- Dont use original camera info -->
     <remap from="/stereo/left/camera_info" to="/null/left/camera_info" />
-  </node>  
+  </node>
   <node name="camera_transform" pkg="tf" type="static_transform_publisher" args="$(arg parent_transform) $(arg parent_frame) /ps4eye_frame 10"/>
 
   <node pkg="ps4eye" type="camera_info_publisher.py" name="camera_info_publisher" >
-    <param name="left_file_name"  value="$(find ps4eye)/camera_info/left.yaml" />
-    <param name="right_file_name" value="$(find ps4eye)/camera_info/right.yaml" />
+    <param name="left_file_name"  value="$(arg camera_info_file_left)"  />
+    <param name="right_file_name" value="$(arg camera_info_file_right)" />
   </node>
   <node name="stereo_image_proc" pkg="stereo_image_proc" type="stereo_image_proc" ns="stereo"/>
 </launch>


### PR DESCRIPTION
`stereo.launch`を外部からincludeしたときにキャリブファイルを設定したかったので、
`camera_info_file_left`と`right`というargを付け加えました。
