### PR TITLE
Bagfile player mode

### DIFF
--- a/launch/stereo.launch
+++ b/launch/stereo.launch
@@ -63,7 +63,9 @@
     <!-- Dont use original camera info -->
     <remap from="/stereo/left/camera_info" to="/null/left/camera_info" />
   </node>
-  <node name="camera_transform" pkg="tf" type="static_transform_publisher" args="$(arg parent_transform) $(arg parent_frame) /ps4eye_frame 10"/>
+
+  <arg name="PUBLISH_TF" default="true" />
+  <node name="camera_transform" pkg="tf" type="static_transform_publisher" args="$(arg parent_transform) $(arg parent_frame) /ps4eye_frame 10" if="$(arg PUBLISH_TF)"/>
 
   <node pkg="ps4eye" type="camera_info_publisher.py" name="camera_info_publisher" >
     <param name="left_file_name"  value="$(arg camera_info_file_left)"  />

--- a/launch/stereo.launch
+++ b/launch/stereo.launch
@@ -28,7 +28,7 @@
   <arg name="width" default="1748"/>
   <arg name="height" default="408"/>
   <arg name="PUBLISH_FRAME" default="false"/>
-  <node name="gscam_driver" pkg="gscam" type="gscam" output="screen">
+  <node name="gscam_driver" pkg="gscam" type="gscam" output="screen" if="$(arg DEVICE)">
     <param name="camera_name" value="default"/>
     <param name="gscam_config" value="v4l2src device=$(arg DEVICE) ! video/x-raw-yuv,framerate=$(arg FPS),width=$(arg width),height=$(arg height) ! ffmpegcolorspace"/>
     <param name="frame_id" value="/ps4eye_frame"/>


### PR DESCRIPTION
bagfileを用いることを想定しています．

```
% rosbag record /camera/camera_info /camera/image_raw
```

を行い，再生する場合にgscamだけを無効にしたいので，
`DEVICE=false`の場合gscamのノードをあげないようにしてあります．

これだけだと，`static_transform_publisher`が出力するtfが現在のものになるため，
rvizで表示できない不都合があります．
これを回避するためにはタイムスタンプをいじってtfを出力させるかtfも同時にとっておくかになりますが，
どちらの場合にも`static_transform_publisher`は切っておく必要があります．
このため，`PUBLISH_TF`を追加し，tfの出力を選択するようにしました．

よってbagを用いた場合，以下の方法で三次元復元を行わせることができます．

```
$ roslaunch ps4eye stereo.launch PUBLISH_TF:=false DEVICE:=false
```

ところで，似たような未使用引数`PUBLISH_FRAME`がありますが，これはどのような意図でしょうか？
もしこれを使っても良いならそのようにしておきます．
