### PR TITLE
use load_driver, instead of setting DEVICE false to check use real camer...

### DIFF
--- a/launch/stereo.launch
+++ b/launch/stereo.launch
@@ -21,6 +21,7 @@
 
   <!-- This launchfile should bring up a node that broadcasts a ros image
        transport on /webcam/image_raw -->
+  <arg name="load_driver" default="true" />
   <arg name="DEVICE" default="/dev/video1"/>
   <!-- The GStreamer framerate needs to be an integral fraction -->
   <arg name="FPS" default="60/1"/>
@@ -28,7 +29,7 @@
   <arg name="width" default="1748"/>
   <arg name="height" default="408"/>
   <arg name="PUBLISH_FRAME" default="false"/>
-  <node name="gscam_driver" pkg="gscam" type="gscam" output="screen" if="$(arg DEVICE)">
+  <node name="gscam_driver" pkg="gscam" type="gscam" output="screen" if="$(arg load_driver)">
     <param name="camera_name" value="default"/>
     <param name="gscam_config" value="v4l2src device=$(arg DEVICE) ! video/x-raw-yuv,framerate=$(arg FPS),width=$(arg width),height=$(arg height) ! ffmpegcolorspace"/>
     <param name="frame_id" value="/ps4eye_frame"/>


### PR DESCRIPTION
すいません，チェック漏れでした．前回の変更点で実機が使えなくなっていたので修正しました．
DEVICEがboolであることを期待されてしまうため，
`openni2_launch`に合わせる形で`load_driver`というargを追加しました．
実機，bag双方で確認済みです．
お手数をおかけします．
