### PR TITLE
added ps4eye for rosrun path and deleted the URL of the original ps4e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@
   If you are using ubuntu, please check [this page](http://kernel.ubuntu.com/~kernel-ppa/mainline/v3.17.3-vivid/) to update kernel
 * You'll need Pyusb 1.0 or the script executed in the udev rules will silently fail.
     sudo pip install --pre pyusb
-* Clone [ps4eye github repo](https://github.com/ps4eye/ps4eye)
 
 ## Usage
 
@@ -34,7 +33,7 @@ $ rosrun ps4eye create_udev_rules
 
 3. Run stereo.launch. DEVICE option is used specify video device. You can bring up stereo viewer if viewer option is true.
 ```
-$ roslaunch stereo.launch DEVICE:=/dev/video0 viewer:=true
+$ roslaunch ps4eye stereo.launch DEVICE:=/dev/video0 viewer:=true
 ```
 4. If you want to run the viewer individually, use this command.
 ```


### PR DESCRIPTION
Added directory path for rosrun.
Deleted the link to the original ps4eye repository that is no longer used and confusing.
